### PR TITLE
Fix Linux Screen Lock in UBUNTU and OS Distro Detection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,10 +107,15 @@ function checkScreenLock() {
       .trim();
     return parseInt(timeout, 16) / 60;
   } else if (system === "linux") {
-    const linuxDesktop = execSync("env | grep XDG_SESSION_DESKTOP")
+    let linuxDesktop = execSync("env | grep XDG_SESSION_DESKTOP")
       .toString()
       .split("=")?.[1]
       .trim();
+
+    if (linuxDesktop === "ubuntu") {
+      linuxDesktop = "gnome";
+    }
+    
     const lockEnabled = execSync(
       `gsettings get org.${linuxDesktop}.desktop.screensaver lock-enabled`
     )

--- a/src/main.js
+++ b/src/main.js
@@ -149,7 +149,7 @@ function getOSInfo() {
       osVersion = os.release();
       break;
     case "linux":
-      osName = "Linux";
+      osName = "Linux | " + execSync("lsb_release -is").toString().trim();
       try {
         osVersion = execSync("lsb_release -rs").toString().trim();
       } catch (error) {


### PR DESCRIPTION
### Description:
This PR brings further improvements to the detection of screen lock settings and operating system information for Linux devices, ensuring better compatibility and more accurate results. The changes affect how we determine the desktop environment and handle OS information, especially for Ubuntu-based systems.

### Changes Overview:
#### Screen Lock Detection:
Modified the detection of the Linux desktop environment using the XDG_SESSION_DESKTOP environment variable.
Added special handling for Ubuntu: if the desktop environment is identified as "Ubuntu", it is mapped to "gnome" for compatibility with the screen lock settings query (gsettings).

#### Operating System Info:
Enhanced the OS Name detection for Linux systems to include the distribution name (e.g., "Ubuntu", "Debian", etc.). This is achieved by running the lsb_release -is command, which retrieves the distribution name and appends it to the OS name.
Refined OS version detection by running lsb_release -rs to extract the specific release version of the distribution.
This change ensures that the OS name is no longer a generic "Linux", but provides more context about the specific distribution running on the device.

![image](https://github.com/user-attachments/assets/c6dc572b-86bd-48ed-bad8-67e9d769d646)
