### PR TITLE
Fix Screen Lock Detection Logic for macOS

### DIFF
--- a/src/checks/screenLock.ts
+++ b/src/checks/screenLock.ts
@@ -1,7 +1,11 @@
 import os from "os";
-import {execPowershell, executeQuery} from "../utils/utils";
-import {execSync} from "child_process";
+import { execPowershell } from "../utils/utils";
+import { execSync } from "child_process";
 
+const getDisplaySleep = (mode: "Battery Power" | "AC Power") => {
+  const output = execSync(`pmset -g custom | awk '/${mode}/,/displaysleep/ {if ($1 == "displaysleep") print $2}'`).toString().trim();
+  return parseInt(output)
+}
 function checkMacOsScreenLock() {
   try {
     const output = execSync("sysadminctl -screenLock status 2>&1")
@@ -11,7 +15,12 @@ function checkMacOsScreenLock() {
     if (output.includes("screenLock is off")) {
       return null;
     } else if (output.includes("screenLock delay is immediate")) {
-      return 1;
+      const screenSaver = parseInt(execSync("defaults -currentHost read com.apple.screensaver idleTime").toString().trim()) / 60;
+      const displaySleepOnBattery = getDisplaySleep("Battery Power");
+      const displaySleepOnAC = getDisplaySleep("AC Power");
+      const longestPeriod = Math.max(screenSaver, displaySleepOnBattery, displaySleepOnAC);
+      // if period is 0 it means the screen does not lock at all
+      return longestPeriod === 0 ? null : longestPeriod;
     } else {
       const match = output.match(/screenLock delay is (\d+) seconds/);
       if (match && match[1]) {


### PR DESCRIPTION
# Summary:
This PR refactors the logic for determining the screen lock delay on macOS, introducing a more comprehensive approach to handle both screen saver and display sleep settings. The changes are aimed at improving the reliability of detecting when the screen will lock.

## New getDisplaySleep function:
A new helper function, getDisplaySleep(mode), has been added to retrieve the displaysleep value from pmset for both Battery and AC Power modes. It uses execSync to extract the time in minutes before the display sleeps.

## Screen Lock Logic Enhancements:
The previous approach, which returned 1 for an immediate screen lock delay, has been replaced with more comprehensive logic that checks:
- Screen saver idle time.
- Display sleep on battery.
- Display sleep on AC power.

The function now returns the longest of these values to determine the screen lock delay. If the longest value is 0, it indicates no screen lock, and null is returned. Otherwise, the longest period is used to ensure accurate screen locking behavior.

<img width="487" alt="image" src="https://github.com/user-attachments/assets/117f4a46-5269-4b27-b8ff-0d895f4d1052">

![image](https://github.com/user-attachments/assets/a1acd152-1cda-43f9-9fba-91713782231f)

