### PR TITLE
feat: Simplify disk encryption on windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ async function main() {
   const { osName, osVersion } = getOSInfo();
 
   const report = {
-    disk_encrypted: !!encryption.encryptionMethod,
-    encryption_type: encryption.encryptionMethod || null,
+    disk_encrypted: !!encryption,
+    encryption_type: encryption || null,
     antivirus_detected: !!antivirus,
     antivirus_name: antivirus || null,
     screen_lock_active: screenLockTime !== null,


### PR DESCRIPTION
# Avoid using root permissions on disk encryption check

## Description

This command:
    `(New-Object -ComObject Shell.Application).NameSpace('C:').Self.ExtendedProperty('System.Volume.BitLockerProtection')`

returns the next values: 
  - unencryptable: 0,
  - encrypted: 1,
  - not_encrypted: 2,
  - encryption_in_progress: 3,

So we can use it