### PR TITLE
Search also for patterns in spanish when checking screen lock on Windows

### DIFF
--- a/src/checks/antivirus.ts
+++ b/src/checks/antivirus.ts
@@ -23,7 +23,7 @@ function checkMacOsAntivirus() {
 function checkWindowsAntivirus() {
   const result = execPowershell(
     `wmic /node:localhost /namespace:\\\\root\\SecurityCenter2 path AntiVirusProduct Get DisplayName`
-  ).toString();
+  );
 
   const antivirusNames = result
     .split("\n")

--- a/src/checks/diskEncryption.ts
+++ b/src/checks/diskEncryption.ts
@@ -22,9 +22,7 @@ const BITLOCKER_STATUS = {
 function checkWindowsDiskEncryption() {
   const result = execPowershell(
     `(New-Object -ComObject Shell.Application).NameSpace('C:').Self.ExtendedProperty('System.Volume.BitLockerProtection')`
-  )
-    .toString()
-    .trim();
+  );
   if (result === BITLOCKER_STATUS["encrypted"].toString()) {
     return "BitLocker";
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -14,5 +14,5 @@ export function execPowershell(
   command: string,
   options?: ExecSyncOptionsWithBufferEncoding
 ) {
-  return execSync(command, { shell: "pwsh", ...options });
+  return execSync(command, { shell: "pwsh", ...options }).toString().trim();
 }


### PR DESCRIPTION
This PR considers the installed preferred language to accurately verify if the screen lock is enabled. Additionally, minor refactors were made.