### PR TITLE
Linux: Add support for AwesomeWM

### DIFF
--- a/src/checks/diskEncryption.ts
+++ b/src/checks/diskEncryption.ts
@@ -31,7 +31,7 @@ function checkWindowsDiskEncryption() {
 
 function checkLinuxDiskEncryption() {
   // Check for ecryptfs
-  const ecryptfsCheck = execSync("mount | grep ecryptfs").toString();
+  const ecryptfsCheck = execSync("mount | grep ecryptfs | cat").toString();
   if (ecryptfsCheck.includes("ecryptfs")) {
     return "ecryptfs";
   }

--- a/src/checks/screenLock.ts
+++ b/src/checks/screenLock.ts
@@ -100,6 +100,13 @@ function checkLinuxScreenLock() {
     linuxDesktop = "gnome";
   }
 
+  if (linuxDesktop === "awesome") {
+    const sessions = execSync("ls /usr/bin/*session");
+    if (sessions.includes("gnome")) {
+      linuxDesktop = "gnome";
+    }
+  }
+
   const lockEnabled = execSync(
     `gsettings get org.${linuxDesktop}.desktop.screensaver lock-enabled`
   )

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,14 @@ import { sendReportToSupabase, getUserId } from "./utils/supabase";
 import { getDeviceSerial, getOSInfo } from "./systemInfo/osInfo";
 
 async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  if (dryRun) {
+    console.log("Dry run mode...");
+  }
+
   console.log("Checking system security...");
 
-  const userId = await getUserId();
+  const userId = await getUserId(dryRun);
   const deviceId = getDeviceSerial();
 
   const encryption = checkDiskEncryption();
@@ -38,7 +43,11 @@ async function main() {
   console.log(diskEncryptionToString(encryption));
   console.log(screenLockToString(screenLockTime));
 
-  await sendReportToSupabase(userId, deviceId, report);
+  if (dryRun) {
+    console.log(JSON.stringify({ userId, deviceId, report}, null, 4));
+  } else {
+    await sendReportToSupabase(userId, deviceId, report);
+  }
 
   console.log("Press Enter to close...");
   process.stdin.once("data", () => {


### PR DESCRIPTION
I run https://awesomewm.org/ tiling window manager which shows up everywhere as `awesome` (like in `$XDG_SESSION_DESKTOP`). Added an extra detection step when `awesome` is encountered.

Also added a `npm start -- --dry-run` option for local testing.

Fixed an early abort on `grep ecryptfs` (if not found, grep returns non-zero, so subsequent checks are aborted, because `execSync()` throws on non-zero exit code).