### PR TITLE
Change the way we are getting the device serial on windows

### DIFF
--- a/src/systemInfo/osInfo.ts
+++ b/src/systemInfo/osInfo.ts
@@ -43,7 +43,7 @@ export function getDeviceSerial() {
         .trim();
       break;
     case "win32":
-      serial = execSync("wmic os get serialnumber")
+      serial = execSync("wmic bios get serialnumber")
         .toString()
         .split("\n")[1]
         .trim();


### PR DESCRIPTION
On Windows machines, we currently use the following command to retrieve the device ID:

```
wmic os get serialnumber
```

However, this command returns the Windows serial number, which may vary between Windows installations.
This PR updates the logic to use the BIOS serial number instead:

```
wmic bios get serialnumber
```

as it provides a more stable and consistent identifier across system reinstalls/updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of device serial number retrieval on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->